### PR TITLE
Fixed missing curl issue on mesos slave image build

### DIFF
--- a/mesos-slave/Dockerfile
+++ b/mesos-slave/Dockerfile
@@ -1,3 +1,4 @@
 FROM mesosphere/mesos-slave:0.26.0-0.2.145.ubuntu1404
-RUN apt-get install curl
+RUN apt-get update
+RUN apt-get -y install curl
 RUN curl -sSL https://get.docker.com/ | sh


### PR DESCRIPTION
`docker-compose` was failing because apt cache from mesos-slave image was too old and needed to be updated, and `-y` option was missing in `install` command
